### PR TITLE
Integrate JDK9 ALPN Negotiator

### DIFF
--- a/api/src/main/java/org/glassfish/grizzly/npn/AlpnServerNegotiator.java
+++ b/api/src/main/java/org/glassfish/grizzly/npn/AlpnServerNegotiator.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2014, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -12,9 +13,15 @@
  * https://www.gnu.org/software/classpath/license.html.
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *   Payara Services - Make class JDK 9 Compatible
  */
 
 package org.glassfish.grizzly.npn;
+
+import java.util.List;
+import java.util.function.BiFunction;
 
 import javax.net.ssl.SSLEngine;
 
@@ -28,7 +35,7 @@ import javax.net.ssl.SSLEngine;
  *
  * <p>
  */
-public interface AlpnServerNegotiator {
+public interface AlpnServerNegotiator extends BiFunction<SSLEngine, List<String>, String> {
 
     /**
      * <p>
@@ -42,5 +49,9 @@ public interface AlpnServerNegotiator {
      * @return the selected protocol.
      */
     String selectProtocol(SSLEngine sslEngine, String[] clientProtocols);
+
+    default String apply(SSLEngine sslEngine, List<String> clientProtocols) {
+        return selectProtocol(sslEngine, clientProtocols.toArray(new String[0]));
+    }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -123,8 +124,8 @@
                 <inherited>true</inherited>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
The JDK 9 ALPN APIs use a BiFunction ALPN negotiator, so JDK 9 support requires that grizzly-npn-api use that interface