### PR TITLE
Applied Eclipse Parent v2.0.0-M1, which uses Central.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2025 Contributors to the Eclipse Foundation.
     Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +32,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
+                <version>6.0.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -44,12 +45,12 @@
                     <dependency>
                         <groupId>org.osgi</groupId>
                         <artifactId>org.osgi.core</artifactId>
-                        <version>4.2.0</version>
+                        <version>6.0.0</version>
                     </dependency>
                     <dependency>
                         <groupId>org.osgi</groupId>
                         <artifactId>org.osgi.compendium</artifactId>
-                        <version>4.2.0</version>
+                        <version>5.0.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.6</version>
+        <version>2.0.0-M1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -34,13 +34,16 @@
 
     <url>https://projects.eclipse.org/projects/ee4j.grizzly</url>
     <issueManagement>
-        <system>JIRA</system>
-        <url>https://github.com/eclipse-ee4j/grizzly-npn/issues</url>
+        <system>GitHub</system>
+        <url>https://github.com/eclipse-ee4j/glassfish-grizzly-npn/issues</url>
     </issueManagement>
     <mailingLists>
         <mailingList>
-            <name>Grizzly Developer List</name>
-            <archive>grizzly-dev@eclipse.org</archive>
+            <name>GlassFish mailing list</name>
+            <post>glassfish-dev@eclipse.org</post>
+            <subscribe>https://dev.eclipse.org/mailman/listinfo/glassfish-dev</subscribe>
+            <unsubscribe>https://dev.eclipse.org/mailman/listinfo/glassfish-dev</unsubscribe>
+            <archive>https://dev.eclipse.org/mhonarc/lists/glassfish-dev/</archive>
         </mailingList>
     </mailingLists>
     <developers>
@@ -55,16 +58,18 @@
     </developers>
     <licenses>
         <license>
-            <name>EPL-2.0</name>
-            <url>http://www.eclipse.org/legal/epl-2.0</url>
+            <name>Eclipse Public License v. 2.0</name>
+            <url>https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt</url>
+            <distribution>repo</distribution>
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git@github.com:eclipse-ee4j/grizzly-npn.git</connection>
+        <connection>scm:git:git@github.com:eclipse-ee4j/glassfish-grizzly-npn.git</connection>
         <developerConnection>
-            scm:git:git@github.com:eclipse-ee4j/grizzly-npn.git
+            scm:git:git@github.com:eclipse-ee4j/glassfish-grizzly-npn.git
         </developerConnection>
-        <url>https://github.com/eclipse-ee4j/grizzly-npn</url>
+        <url>https://github.com/eclipse-ee4j/glassfish-grizzly-npn</url>
+        <tag>HEAD</tag>
     </scm>
     <organization>
         <name>Oracle Corporation</name>
@@ -76,7 +81,7 @@
             <plugin>
                <groupId>org.glassfish.copyright</groupId>
                <artifactId>glassfish-copyright-maven-plugin</artifactId>
-               <version>1.46</version>
+               <version>2.4</version>
                <configuration>
                   <scm>git</scm>
                   <scmOnly>true</scmOnly>
@@ -89,76 +94,36 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.2</version>
+                <version>3.6.2</version>
                 <executions>
                     <execution>
-                        <id>enforce-java</id>
+                        <id>enforce-maven</id>
                         <goals>
                             <goal>enforce</goal>
                         </goals>
                        <configuration>
                             <rules>
-                                <requireProperty>
-                                    <property>java.vm.name</property>
-                                    <message>You must use JDK 8u252+ to build
-                                        this module.
-                                    </message>
-                                    <!--<regex>^(OpenJDK).*</regex>-->
-                                </requireProperty>
+                                <requireJavaVersion>
+                                    <version>[17,)</version>
+                                </requireJavaVersion>
+                                <requireMavenVersion>
+                                    <version>3.8.9</version>
+                                </requireMavenVersion>
                             </rules>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <mavenExecutorId>forked-path</mavenExecutorId>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <preparationGoals>clean install</preparationGoals>
-                    <pushChanges>false</pushChanges>
-                    <goals>deploy -Dmaven.test.skip=true</goals>
-                </configuration>
-            </plugin>
-            <plugin>
-                <inherited>true</inherited>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>17</release>
+                    <compilerArgument>-Xlint:unchecked,deprecation,fallthrough,finally,cast,dep-ann,empty,overrides</compilerArgument>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>release-sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
     <modules>
         <module>api</module>


### PR DESCRIPTION
(Trivial) Updated the basic information in the pom.

I tested it with the following CI and it works fine:
- https://ci.eclipse.org/glassfish/view/Grizzly/job/grizzly-npn-deploy-snapshot/1/