### PR TITLE
Applied  Java Platform Module System (JPMS)

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+module org.glassfish.grizzly.npn {
+    
+    exports org.glassfish.grizzly.npn;
+    
+    opens org.glassfish.grizzly.npn;
+}


### PR DESCRIPTION
- Fixed #26 : Added module-info.java, and used the `org.glassfish.grizzly.npn` package name as the module name.